### PR TITLE
Add /unsubscribe to reserved notion.so endpoints

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -5,7 +5,7 @@ var tabUrl = loc.href;
 var reservedList = ["signup", "login", "careers", "pricing", "customers", "guides", "enterprise", 
                     "mobile", "desktop", "web-clipper", "product", "wikis", "projects", "notes",
                     "teams", "remote", "personal", "startups", "students", "educators", "evernote",
-                    "confluence", "api-beta", "about", "tools-and-craft"];
+                    "confluence", "api-beta", "about", "tools-and-craft", "unsubscribe"];
 
 // Get extension options
 storage.get(["OINStatus", "OINCloseTab", "OINCloseTime", "OINWorkspaces"], function (data) {


### PR DESCRIPTION
Hi, been really enjoying this plugin, thanks for developing!

I noticed that the `/unsubscribe` endpoint is another that should be excluded from being opened in the Notion app. It's used to unsubscribe from Notion email notifications. This PR addresses that.

It may also be a good idea to add a setting to exclude user defined endpoints, or even modify the whole `reservedList` array. If this is desirable I'd be keen to build it!