### PR TITLE
Replace /native redirect with support for new notion:// protocol

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -35,7 +35,7 @@ storage.get(["OINStatus", "OINCloseTab", "OINCloseTime", "OINWorkspaces"], funct
     if ((statusExt || statusExt == undefined) && reservedMatch != null) {
       if (match != null) {
         if (tabUrl.indexOf("/native/") == -1) {
-          loc.replace(tabUrl.replace(match[2], match[2] + "native/"));
+          loc.replace(tabUrl.replace(/^https?\:\/\//i, 'notion://'));
         }
         if (linkTab) {
           setTimeout(() => {


### PR DESCRIPTION
## Problem

Notion's support for the `/native` url is a little wonky. They recently added support for the `notion://` protocol which more reliably opens the app. [See article here](https://thomasjfrank.com/how-to-share-notion-links-that-open-directly-in-the-app/)

## Solution

Redirect Notion tabs from `https://notion.so/...` to `notion://notion.so/...`