### PR TITLE
Add /help to reserved notion.so endpoints

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -5,7 +5,7 @@ var tabUrl = loc.href;
 var reservedList = ["signup", "login", "careers", "pricing", "customers", "guides", "enterprise", 
                     "mobile", "desktop", "web-clipper", "product", "wikis", "projects", "notes",
                     "teams", "remote", "personal", "startups", "students", "educators", "evernote",
-                    "confluence", "api-beta", "about", "tools-and-craft", "unsubscribe"];
+                    "confluence", "api-beta", "about", "tools-and-craft", "unsubscribe", "help"];
 
 // Get extension options
 storage.get(["OINStatus", "OINCloseTab", "OINCloseTime", "OINWorkspaces"], function (data) {


### PR DESCRIPTION
Like in #5, I found another notion.so endpoint missing from the reserved endpoints array. /help contains FAQ-like documents which are themselves Notion pages, so currently the plugin actually causes the browser to loop opening new tabs for this endpoint.
Thanks again for this great tool! 🙂 