### PR TITLE
Prevent the Notion Blog pages opening the client

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -6,7 +6,7 @@ var reservedList = ["signup", "login", "careers", "pricing", "customers", "guide
                     "mobile", "desktop", "web-clipper", "product", "wikis", "projects", "notes",
                     "teams", "remote", "personal", "startups", "students", "educators", "evernote",
                     "confluence", "api-beta", "about", "tools-and-craft", "unsubscribe", "help",
-                    "templates"];
+                    "templates", "blog"];
 
 // Get extension options
 storage.get(["OINStatus", "OINCloseTab", "OINCloseTime", "OINWorkspaces"], function (data) {


### PR DESCRIPTION
I noticed I was stuck in a loop between Chrome and Notion Desktop (at least on OS X) when I tried to read one of their blog posts.
For example: https://notion.so/blog/notion-product-management-system-align-every-team

I saw this reserved word list so adding `blog` should resolve the issue.

Please let me know if there is anything else I need to add :) Thanks!